### PR TITLE
Add option to limit range of port for client_server

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -5,10 +5,18 @@ var log = require('book');
 var optimist = require('optimist');
 
 var argv = optimist
-    .usage('Usage: $0 --port [num]')
+    .usage('Usage: $0 --port [--min-proxy-port] [--max-proxy-port] [num]')
     .options('port', {
         default: '80',
         describe: 'listen on this port for outside requests'
+    })
+    .options('min-proxy-port', {
+        default: '1024',
+        describe: 'minimum port number used for proxy channel'
+    })
+    .options('max-proxy-port', {
+        default: '65535',
+        describe: 'minimum port number used for proxy channel'
     })
     .argv;
 
@@ -24,7 +32,9 @@ process.once('uncaughtException', function(err) {
 });
 
 var server = require('../server')({
-    max_tcp_sockets: 5
+    max_tcp_sockets: 5,
+    min_proxy_port: parseInt(argv['min-proxy-port']),
+    max_proxy_port: parseInt(argv['max-proxy-port'])
 });
 
 server.listen(argv.port, function() {

--- a/server.js
+++ b/server.js
@@ -105,7 +105,9 @@ function upstream_response(d, start, end) {
 
 var handle_req = function (req, res) {
 
-    var max_tcp_sockets = req.socket.server.max_tcp_sockets;
+    var max_tcp_sockets = req.socket.server.max_tcp_sockets,
+        min_proxy_port = req.socket.server.min_proxy_port,
+        max_proxy_port = req.socket.server.max_proxy_port;
 
     // ignore favicon
     if (req.url === '/favicon.ico') {
@@ -171,8 +173,13 @@ var handle_req = function (req, res) {
         waiting: []
     };
 
+    var proxy_port = (
+        Math.floor(Math.random() * (max_proxy_port - min_proxy_port)) +
+        min_proxy_port
+    );
+
     var client_server = net.createServer();
-    client_server.listen(function() {
+    client_server.listen(proxy_port, function() {
         var port = client_server.address().port;
         log.info('tcp server listening on port: %d', port);
 
@@ -316,6 +323,8 @@ module.exports = function(opt) {
     var server = createRawServer();
 
     server.max_tcp_sockets = opt.max_tcp_sockets || 5;
+    server.min_proxy_port = opt.min_proxy_port || 1;
+    server.max_proxy_port = opt.max_proxy_port || 65535;
     server.on('request', handle_req);
     server.on('upgrade', handle_upgrade);
 


### PR DESCRIPTION
It would be useful when the router is masking outer ports.
