### PR TITLE
Add more verbose error for ECONNREFUSED

### DIFF
--- a/client.js
+++ b/client.js
@@ -62,7 +62,13 @@ var connect = function(opt) {
             var remote = net.connect(remote_opt);
 
             remote.once('error', function(err) {
-                if (err.code !== 'ECONNREFUSED') {
+
+                // emit connection refused errors immediately, because they
+                // indicate that the tunnel can't be established.
+                if (err.code === 'ECONNREFUSED') {
+                    ev.emit('error', new Error('connection refused: ' + remote_host + ':' + remote_port + ' (check your firewall settings)'));
+                }
+                else {
                     remote.emit('error', err);
                 }
 


### PR DESCRIPTION
If the tunnel server can be reached (at e.g. http://localtunnel.me/?new) but the tunnel (e.g. `grpi.localtunnel.me:44827`) can't actually be established, the client currently gets stuck in a loop retrying forever with no indication as to what's wrong. This doesn't fix the loop, since it does seem desirable to retry forever, but logs:

```
[Error: connection refused: localtunnel.me:44827 (check your firewall settings)]
```

IMO, this closes #24.
