### PR TITLE
Allow restricting tunnel to a specified --path on target host/post

### DIFF
--- a/bin/client
+++ b/bin/client
@@ -14,7 +14,11 @@ var argv = require('optimist')
     .options('local-host', {
         describe: 'tunnel traffic to this host instead of localhost'
     })
+    .options('path', {
+        describe: 'prepend to request path of tunnel traffic'
+    })
     .default('local-host', 'localhost')
+    .default('path', '')
     .describe('port', 'internal http server port')
     .argv;
 
@@ -23,6 +27,7 @@ var opt = {
     port: argv.port,
     local_host: argv['local-host'],
     subdomain: argv.subdomain,
+    path: argv.path
 }
 
 lt_client(opt.port, opt, function(err, tunnel) {


### PR DESCRIPTION
This pull request adds a `path` option (or `--path` in the CLI) and corresponding tests. All requests to a tunnel with a configured `path` will have that `path` prepended to the target tunneled path.

For example, a tunnel started with `lt --port 8080 --path /some-path --subdomain path-test` and requested through `https://path-test.localtunnel.me/` will hit `http://localhost:8080/some-path/`. Likewise for a request to `https://path-test.localtunnel.me/here`, which will hit `http://localhost:8080/some-path/here`.

This pull request also ups the Mocha tests' default timeout as some tests were failing from here in New Zealand due to slow requests. ;)
