### PR TITLE
Return client

### DIFF
--- a/client.js
+++ b/client.js
@@ -312,4 +312,5 @@ module.exports = function localtunnel(port, opt, fn) {
 
         fn(null, client);
     });
+    return client;
 };


### PR DESCRIPTION
This allows manipulating the client from outside. Allowing, for example, to close a connection.

```
client.close();
```
