### PR TITLE
don't emit ETIMEDOUT-errors

### DIFF
--- a/client.js
+++ b/client.js
@@ -83,7 +83,7 @@ TunnelCluster.prototype.open = function() {
         if (err.code === 'ECONNREFUSED') {
             self.emit('error', new Error('connection refused: ' + remote_host + ':' + remote_port + ' (check your firewall settings)'));
         }
-        else {
+        else if (err.code !== 'ETIMEDOUT') {
             self.emit('error', err);
         }
 


### PR DESCRIPTION
I'm having a really shitty internet connection at home, and getting ETIMEDOUT-erros on the tcp-stream in TunnelCluster from time to time - this seem to fix that.
