### PR TITLE
Bumped deps to fix upstream SPDX license issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "git://github.com/shtylman/localtunnel.git"
   },
   "dependencies": {
-    "request": "2.11.4",
-    "yargs": "3.15.0",
-    "debug": "0.7.4",
+    "request": "2.65.0",
+    "yargs": "3.29.0",
+    "debug": "2.2.0",
     "openurl": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Thanks for this awesome service!

This fixes license audit warnings when using localtunnel in a toolchain.

Some of the outdated dependencies had invalid SPDX license identifiers that have since been fixed upstream.