### PR TITLE
Emit socket errors, so they can be handled

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -88,6 +88,11 @@ Tunnel.prototype._establish = function(info) {
         self.emit('url', info.url);
     });
 
+    // re-emit socket error
+    tunnels.on('error', function(err) {
+        self.emit('error', err);
+    });
+
     var tunnel_count = 0;
 
     // track open count


### PR DESCRIPTION
With this PR socket errors are emited be the `localtunnel` object. This allows handling of #81.

Example:
```
var tunnel = localtunnel(port, function(err, tunnel) {});

tunnel.on('error', function(err) {
    console.log("error happend");
    console.log(err);
});
```