### PR TITLE
Fix bug w/ HeaderHostTransformer and binary data

### DIFF
--- a/lib/HeaderHostTransformer.js
+++ b/lib/HeaderHostTransformer.js
@@ -19,11 +19,11 @@ util.inherits(HeaderHostTransformer, Transform);
 
 HeaderHostTransformer.prototype._transform = function (chunk, enc, cb) {
     var self = this;
-    chunk = chunk.toString();
 
     // after replacing the first instance of the Host header
     // we just become a regular passthrough
     if (!self.replaced) {
+        chunk = chunk.toString();
         self.push(chunk.replace(/(\r\nHost: )\S+/, function(match, $1) {
             self.replaced = true;
             return $1 + self.host;


### PR DESCRIPTION
I found this while debugging an issue I was having with SendGrid's Inbound Parse webhook.

In my testing, I was getting "multipart/form-data" request bodies that seemed to end abruptly. This was due to binary data being converted to string data unnecessarily.

This one-line patch fixes the issue by not converting chunks to strings once the Host header (which should always be before any binary data) has been found and transformed.