### PR TITLE
Upgraded vulnerable request dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # localtunnel
 
-[![Build Status](https://travis-ci.org/localtunnel/localtunnel.svg?branch=master)](https://travis-ci.org/localtunnel/localtunnel) [![Known Vulnerabilities](https://snyk.io/test/github/localtunnel/localtunnel/badge.svg)](https://snyk.io/test/github/localtunnel/localtunnel)
+[![Build Status](https://travis-ci.org/localtunnel/localtunnel.svg?branch=master)](https://travis-ci.org/localtunnel/localtunnel)
 
 localtunnel exposes your localhost to the world for easy testing and sharing! No need to mess with DNS or deploy just to have others test out your changes.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # localtunnel
 
-[![Build Status](https://travis-ci.org/localtunnel/localtunnel.svg?branch=master)](https://travis-ci.org/localtunnel/localtunnel)
+[![Build Status](https://travis-ci.org/localtunnel/localtunnel.svg?branch=master)](https://travis-ci.org/localtunnel/localtunnel) [![Known Vulnerabilities](https://snyk.io/test/github/localtunnel/localtunnel/badge.svg)](https://snyk.io/test/github/localtunnel/localtunnel)
 
 localtunnel exposes your localhost to the world for easy testing and sharing! No need to mess with DNS or deploy just to have others test out your changes.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "0.7.0"
+    "ms" : "^0.7.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "0.7.0",
+    "ms" : "^0.7.0",
     "express": "3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "0.7.0"
+    "ms" : "0.7.0",
     "express": "3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
     "url": "git://github.com/shtylman/localtunnel.git"
   },
   "dependencies": {
-    "request": "2.65.0",
+    "request": "^2.68.0",
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0"
   },
   "devDependencies": {
+    "snyk": "^1.13.3",
     "mocha": "~1.17.0"
   },
   "scripts": {
-    "test": "mocha --ui qunit --reporter list --timeout 10000 -- test/index.js"
+    "test": "snyk test && mocha --ui qunit --reporter list --timeout 10000 -- test/index.js"
   },
   "bin": {
     "lt": "./bin/client"

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
     "openurl": "1.1.0"
   },
   "devDependencies": {
-    "snyk": "^1.13.3",
     "mocha": "~1.17.0"
   },
   "scripts": {
-    "test": "snyk test && mocha --ui qunit --reporter list --timeout 10000 -- test/index.js"
+    "test": "mocha --ui qunit --reporter list --timeout 10000 -- test/index.js"
   },
   "bin": {
     "lt": "./bin/client"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "^0.7.0"
+    "ms" : "0.7.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "request": "2.68.0",
     "yargs": "3.29.0",
     "debug": "2.2.0",
-    "openurl": "1.1.0"
+    "openurl": "1.1.0",
+    "ms" : "0.7.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "0.7.0"
+    "ms" : "0.7.0",
+    "express": "3.0.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/shtylman/localtunnel.git"
   },
   "dependencies": {
-    "request": "^2.68.0",
+    "request": "2.68.0",
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0",
-    "ms" : "0.7.0",
+    "ms" : "0.7.0"
     "express": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`localtunnel` currently uses a vulnerable version of request, that may expose server side memory. 
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/localtunnel/localtunnel/9a1d48764a167ae9fb05f42efdd7de0005e9edfc

This PR upgrades the vulnerable request to the minimal version that isn't vulnerable. 
It's a minor upgrade, so should have no disruption.

I also added `snyk test` to the test process, to help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard), doing so will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
 