### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/shtylman/localtunnel.git"
   },
   "dependencies": {
-    "request": "2.65.0",
+    "request": "2.74.0",
     "yargs": "3.29.0",
     "debug": "2.2.0",
     "openurl": "1.1.0"


### PR DESCRIPTION
This PR is a clean reimplementation of #115 

It updates just the `request` dependency to a recent version which isn't vulnerable to a [ReDos attack due to it depending on an old `tough-cookie` version](https://snyk.io/test/github/localtunnel/localtunnel/9a1d48764a167ae9fb05f42efdd7de0005e9edfc).
