### PR TITLE
Handle Host header parameter transformation allowing for non Windows …

### DIFF
--- a/lib/HeaderHostTransformer.js
+++ b/lib/HeaderHostTransformer.js
@@ -24,7 +24,7 @@ HeaderHostTransformer.prototype._transform = function (chunk, enc, cb) {
     // we just become a regular passthrough
     if (!self.replaced) {
         chunk = chunk.toString();
-        self.push(chunk.replace(/(\r\nHost: )\S+/, function(match, $1) {
+        self.push(chunk.replace(/(\n[H|h]ost: )\S+/, function(match, $1) {
             self.replaced = true;
             return $1 + self.host;
         }));


### PR DESCRIPTION
…EOL and 'host:' as well as 'Host:'
