### PR TITLE
Fixed crash when remote connection closed.

### DIFF
--- a/bin/client
+++ b/bin/client
@@ -43,20 +43,28 @@ var opt = {
     subdomain: argv.subdomain,
 };
 
-lt_client(opt.port, opt, function(err, tunnel) {
-    if (err) {
-        throw err;
-    }
+var client_fn = function () {
+    lt_client(opt.port, opt, function (err, tunnel) {
+        if (err) {
+            console.log("Error ", err);
+        }
 
-    console.log('your url is: %s', tunnel.url);
+        console.log('your url is: %s', tunnel.url);
 
-    if (argv.open) {
-        open_url.open(tunnel.url);
-    }
+        if (argv.open) {
+            open_url.open(tunnel.url);
+        }
 
-    tunnel.on('error', function(err) {
-        throw err;
+        tunnel.on('error', function (err) {
+            try {
+                console.log("Error: $s", err);
+                tunnel.close();
+            } finally {
+                setTimeout(client_fn, 10000);
+            }
+        });
     });
-});
+}
 
+client_fn();
 // vim: ft=javascript

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -66,10 +66,16 @@ TunnelCluster.prototype.open = function() {
             port: local_port
         });
 
-        function remote_close() {
+        function remote_close(had_error) {
             debug('remote close');
             self.emit('dead');
             local.end();
+            if (had_error) {
+                debug('remote had error');
+                if (!remote.destroyed) {
+                    remote.destroy();
+                }
+            }
         };
 
         remote.once('close', remote_close);


### PR DESCRIPTION
### Before:
Run `lt -l localhost -p 3979`, and after some minutes client crashes with error ECONNREFUSED. Without flag `-l` it works properly.
### After:
When exception occurs in program cycle, all tunnels will be closed and then reopened with timeout. 

So tunnel could be run in daemon mode.