### PR TITLE
Add ability to specify env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Below are some common arguments. See `lt --help` for additional arguments
 * `--subdomain` request a named subdomain on the localtunnel server (default is random characters)
 * `--local-host` proxy to a hostname other than localhost
 
+You may also specify arguments via env variables.  E.x.
+
+```
+PORT=3000 lt
+```
+
 ## API ##
 
 The localtunnel client is also usable through an API (for test integration, automation, etc)

--- a/bin/client
+++ b/bin/client
@@ -4,10 +4,11 @@ var open_url = require('openurl');
 
 var argv = require('yargs')
     .usage('Usage: $0 --port [num] <options>')
+    .env(true)
     .option('h', {
         alias: 'host',
         describe: 'Upstream server providing forwarding',
-        default: 'http://localtunnel.me'
+        default: 'http://localtunnel.me',
     })
     .option('s', {
         alias: 'subdomain',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "request": "2.78.0",
-    "yargs": "3.29.0",
+    "yargs": "6.6.0",
     "debug": "2.2.0",
     "openurl": "1.1.0"
   },


### PR DESCRIPTION
Fixes https://github.com/localtunnel/localtunnel/issues/159

Fairly large update in yargs version, other than that just telling yars to parse env variables.