### PR TITLE
Add support for running on Android

### DIFF
--- a/bin/client
+++ b/bin/client
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var lt_client = require('../client');
-var open_url = require('openurl');
 
 var argv = require('yargs')
     .usage('Usage: $0 --port [num] <options>')
@@ -51,6 +50,7 @@ lt_client(opt.port, opt, function(err, tunnel) {
     console.log('your url is: %s', tunnel.url);
 
     if (argv.open) {
+        var open_url = require('openurl');
         open_url.open(tunnel.url);
     }
 

--- a/bin/client
+++ b/bin/client
@@ -50,6 +50,9 @@ lt_client(opt.port, opt, function(err, tunnel) {
     console.log('your url is: %s', tunnel.url);
 
     if (argv.open) {
+        // require 'openurl' only when needed, as it will
+        // crash on some systems that the rest of the
+        // codebase normally runs on. (i.e., Android)
         var open_url = require('openurl');
         open_url.open(tunnel.url);
     }


### PR DESCRIPTION
I am using NodeJS from within Termux on my Android phone, and wanted to get localtunnel setup.  However, when I run

```sh
$ lt ...
/data/data/com.termux/files/usr/lib/node_modules/localtunnel/node_modules/openurl/openurl.js:16
        throw new Error('Unsupported platform: ' + process.platform);
        ^

Error: Unsupported platform: android
    at Object.<anonymous> (/data/data/com.termux/files/usr/lib/node_modules/localtunnel/node_modules/openurl/openurl.js:16:15)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/data/data/com.termux/files/usr/lib/node_modules/localtunnel/bin/client:3:16)
    at Module._compile (module.js:570:32)
```

Even though I am not wanting to open the URL (I did not pass in the `-o` switch), the `openurl` module still gets required and does platform checking.  This PR defers requiring openurl until it is actually needed.