### PR TITLE
Fix for memory leak

### DIFF
--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -83,7 +83,7 @@ TunnelCluster.prototype.open = function() {
 
             remote.removeListener('close', remote_close);
 
-            if (err.code !== 'ECONNREFUSED') {
+            if (err.code === 'ECONNREFUSED') {
                 return remote.end();
             }
 
@@ -105,6 +105,12 @@ TunnelCluster.prototype.open = function() {
             }
 
             stream.pipe(local).pipe(remote);
+            
+            local.once('error', function () {
+                // writable stream (remote) must be manually closed when
+                // readable stream (local) encounters an error to prevent memory leaks 
+                local.unpipe(remote);
+            });
 
             // when local closes, also get a new remote
             local.once('close', function(had_error) {


### PR DESCRIPTION
When local.pipe(remote) produces an error, events were not properly cleaned up on the remote stream. This resulted in a memory leak and eventually the client crashes. This bubbled up and produced the "connection refused: ... (check your firewall settings)" error as well as the event emitter warnings. For example, by default after 2 minutes of an idle socket connection the socket produces a reconnect error. Every time this happens, events are leftover on the remote connection, leaking memory. The remote connection should only be closed if the local connection is refused, otherwise the local should unpipe remote and remote should try to reestablish connection with local.