### PR TITLE
Reference go-localtunnel (issue #163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Clients in other languages
 
 *go* [gotunnelme](https://github.com/NoahShen/gotunnelme)
 
+*go* [go-localtunnel](https://github.com/localtunnel/go-localtunnel)
+
 ## server ##
 
 See [localtunnel/server](//github.com/localtunnel/server) for details on the server that powers localtunnel.


### PR DESCRIPTION
this client implementation supports `net.Listener`, so no need to use a port on localhost.