### PR TITLE
Prefix env vars that localtunnel will look for

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Below are some common arguments. See `lt --help` for additional arguments
 * `--subdomain` request a named subdomain on the localtunnel server (default is random characters)
 * `--local-host` proxy to a hostname other than localhost
 
-You may also specify arguments via env variables.  E.x.
+You may also specify arguments via env variables by prefixing them with `LOCALTUNNEL_`.  E.x.
 
 ```
-PORT=3000 lt
+LOCALTUNNEL_PORT=3000 lt
 ```
 
 ## API ##

--- a/bin/client
+++ b/bin/client
@@ -4,7 +4,7 @@ var open_url = require('openurl');
 
 var argv = require('yargs')
     .usage('Usage: $0 --port [num] <options>')
-    .env(true)
+    .env('LOCALTUNNEL')
     .option('h', {
         alias: 'host',
         describe: 'Upstream server providing forwarding',


### PR DESCRIPTION
I want to take advantage of this, but I also don't want to use such generic variable names as `HOST` and `PORT` in my environment. I could shorten the prefix to `LT` but using the full name made more sense to me.