### PR TITLE
Update debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "axios": "0.17.1",
-    "debug": "2.6.8",
+    "debug": "2.6.9",
     "openurl": "1.1.1",
     "yargs": "6.6.0"
   },


### PR DESCRIPTION
This will get rid of an npm audit message by updating debug to next minor version.

<img width="605" alt="screen shot 2018-06-13 at 3 02 14 pm" src="https://user-images.githubusercontent.com/4149877/41381008-19161a56-6f1b-11e8-8507-4a9ebff5d2c7.png">
