### PR TITLE
init: retry with increasing back-off, maximum nr of retries, log to stderr

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -2,6 +2,7 @@ var url = require('url');
 var EventEmitter = require('events').EventEmitter;
 var axios = require('axios');
 var debug = require('debug')('localtunnel:client');
+var operation = require('retry').operation;
 
 var TunnelCluster = require('./TunnelCluster');
 
@@ -40,7 +41,16 @@ Tunnel.prototype._init = function(cb) {
     // where to quest
     var uri = base_uri + ((assigned_domain) ? assigned_domain : '?new');
 
-    (function get_url() {
+    const retryOpts = Object.assign({
+        retries: Infinity,
+        factor: 1.5,
+        maxTimeout: 20 * 1000
+    }, opt.initRetryOpts || {});
+    const op = operation(retryOpts);
+
+    op.attempt(function get_url(attemptNr) {
+        debug('init attempt', attemptNr);
+
         axios.get(uri, params)
         .then(function(res){
             var body = res.data;
@@ -59,12 +69,19 @@ Tunnel.prototype._init = function(cb) {
                 max_conn: max_conn
             });
         })
-        .catch(function(err){
-            // TODO (shtylman) don't print to stdout?
-            console.log('tunnel server offline: ' + err.message + ', retry 1s');
-            return setTimeout(get_url, 1000);
+        .catch(function(attemptErr){
+            if (op.retry(attemptErr)) {
+                // TODO (shtylman) don't print to stderr?
+                console.log('failed to connect to the tunnel server, retrying', attemptErr);
+                return;
+            }
+
+            const err = op.mainError();
+            // TODO (shtylman) don't print to stderr?
+            console.log('failed to connect to the tunnel server', err);
+            cb(err);
         })
-    })();
+    });
 };
 
 Tunnel.prototype._establish = function(info) {

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -42,7 +42,7 @@ Tunnel.prototype._init = function(cb) {
     var uri = base_uri + ((assigned_domain) ? assigned_domain : '?new');
 
     const retryOpts = Object.assign({
-        retries: Infinity,
+        retries: 20,
         factor: 1.5,
         maxTimeout: 20 * 1000
     }, opt.initRetryOpts || {});

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -72,13 +72,15 @@ Tunnel.prototype._init = function(cb) {
         .catch(function(attemptErr){
             if (op.retry(attemptErr)) {
                 // TODO (shtylman) don't print to stderr?
-                console.log('failed to connect to the tunnel server, retrying', attemptErr);
+                console.error('failed to connect to the tunnel server, retrying', attemptErr);
                 return;
             }
 
-            const err = op.mainError();
+            const actualErr = op.mainError();
+            const err = new Error('failed to connect to the tunnel server');
+            err.actualErr = actualErr;
             // TODO (shtylman) don't print to stderr?
-            console.log('failed to connect to the tunnel server', err);
+            console.error(err);
             cb(err);
         })
     });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "0.19.0",
     "debug": "4.1.1",
     "openurl": "1.1.1",
+    "retry": "^0.12.0",
     "yargs": "6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR tries to make `localtunnel` more usable when it is used programmatically. The current nr of retries of `20` is customisable via `opt.initRetryOpts.retries`.