### PR TITLE
Add reference to angelobreuer/localtunnel-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ _go_ [gotunnelme](https://github.com/NoahShen/gotunnelme)
 
 _go_ [go-localtunnel](https://github.com/localtunnel/go-localtunnel)
 
+_C#/.NET_ [localtunnel-client](https://github.com/angelobreuer/localtunnel-client])
+
 ## server
 
 See [localtunnel/server](//github.com/localtunnel/server) for details on the server that powers localtunnel.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ _go_ [gotunnelme](https://github.com/NoahShen/gotunnelme)
 
 _go_ [go-localtunnel](https://github.com/localtunnel/go-localtunnel)
 
-_C#/.NET_ [localtunnel-client](https://github.com/angelobreuer/localtunnel-client])
+_C#/.NET_ [localtunnel-client](https://github.com/angelobreuer/localtunnel-client)
 
 ## server
 


### PR DESCRIPTION
:wave: I have created a client for the localtunnel server implemented in .NET, and I would like to place it to the others.