### PR TITLE
Better close script

### DIFF
--- a/bin/lt.js
+++ b/bin/lt.js
@@ -101,4 +101,12 @@ if (typeof argv.port !== 'number') {
       console.log(new Date().toString(), info.method, info.path);
     });
   }
+  
+  tunnel.on("close", () => {
+    console.log("Tunnel closed. Exiting");
+    process.exit();
+  });
+  process.on("SIGINT", function () {
+    tunnel.close();
+  });
 })();


### PR DESCRIPTION
When the command is requested to close, the script isn't running the close method of the tunnel.

This requests fix it and maybe prevents subdomains errors like the listed in the issue #403 