### PR TITLE
Added ability to use socks proxy for server/client communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ const localtunnel = require('localtunnel');
 - `local_key` (string) Path to certificate key file for local HTTPS server.
 - `local_ca` (string) Path to certificate authority file for self-signed certificates.
 - `allow_invalid_cert` (boolean) Disable certificate checks for your local HTTPS server (ignore cert/key/ca options).
+- `socks_host` (string) Define socks host for use of socks proxy for localtunnel server connection
+- `socks_port` (string) Define socks port for use of socks proxy for localtunnel server connection
 
 Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) for details on the certificate options.
 

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -42,6 +42,14 @@ const { argv } = yargs
   .option('allow-invalid-cert', {
     describe: 'Disable certificate checks for your local HTTPS server (ignore cert/key/ca options)',
   })
+  .option('socks-host', {
+    describe: 'Socks proxy hostname',
+    implies: 'socks-port'
+  })
+  .option('socks-port', {
+    describe: 'Socks proxy port',
+    implies: 'socks-host'
+  })
   .options('o', {
     alias: 'open',
     describe: 'Opens the tunnel URL in your browser',
@@ -73,6 +81,8 @@ if (typeof argv.port !== 'number') {
     local_key: argv.localKey,
     local_ca: argv.localCa,
     allow_invalid_cert: argv.allowInvalidCert,
+    socks_host: argv.socksHost,
+    socks_port: argv.socksPort,
   }).catch(err => {
     throw err;
   });

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -4,6 +4,8 @@ const { parse } = require('url');
 const { EventEmitter } = require('events');
 const axios = require('axios');
 const debug = require('debug')('localtunnel:client');
+const SocksHttpAgent = require('socks5-http-client/lib/Agent');
+const SocksHttpsAgent = require('socks5-https-client/lib/Agent');
 
 const TunnelCluster = require('./TunnelCluster');
 
@@ -12,6 +14,12 @@ module.exports = class Tunnel extends EventEmitter {
     super(opts);
     this.opts = opts;
     this.closed = false;
+    this.socksHttpAgent = opts.socks_host && opts.socks_port
+        ? new SocksHttpAgent({ socksHost: opts.socks_host, socksPort: opts.socks_port })
+        : null;
+    this.socksHttpsAgent = opts.socks_host && opts.socks_port
+        ? new SocksHttpsAgent({ socksHost: opts.socks_host, socksPort: opts.socks_port })
+        : null;
     if (!this.opts.host) {
       this.opts.host = 'https://localtunnel.me';
     }
@@ -21,7 +29,7 @@ module.exports = class Tunnel extends EventEmitter {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count } = body;
     const { host, port: local_port, local_host } = this.opts;
-    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
+    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert, socks_host, socks_port } = this.opts;
     return {
       name: id,
       url,
@@ -37,6 +45,8 @@ module.exports = class Tunnel extends EventEmitter {
       local_key,
       local_ca,
       allow_invalid_cert,
+      socks_host,
+      socks_port,
     };
     /* eslint-enable camelcase */
   }
@@ -46,6 +56,8 @@ module.exports = class Tunnel extends EventEmitter {
   _init(cb) {
     const opt = this.opts;
     const getInfo = this._getInfo.bind(this);
+    const httpAgent = this.socksHttpAgent;
+    const httpsAgent = this.socksHttpsAgent;
 
     const params = {
       responseType: 'json',
@@ -59,7 +71,10 @@ module.exports = class Tunnel extends EventEmitter {
 
     (function getUrl() {
       axios
-        .get(uri, params)
+        .get(uri, params, {
+          httpAgent,
+          httpsAgent,
+        })
         .then(res => {
           const body = res.data;
           debug('got tunnel information', res.data);

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -3,6 +3,7 @@ const debug = require('debug')('localtunnel:client');
 const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
+const { Socket } = require('socks5-client');
 
 const HeaderHostTransformer = require('./HeaderHostTransformer');
 
@@ -23,6 +24,12 @@ module.exports = class TunnelCluster extends EventEmitter {
     const localPort = opt.local_port;
     const localProtocol = opt.local_https ? 'https' : 'http';
     const allowInvalidCert = opt.allow_invalid_cert;
+    const socksHost = opt.socks_host;
+    const socksPort = opt.socks_port;
+
+    const socksSocket = socksHost && socksPort
+        ? new Socket({ socksHost, socksPort })
+        : null;
 
     debug(
       'establishing tunnel %s://%s:%s <> %s:%s',
@@ -33,11 +40,12 @@ module.exports = class TunnelCluster extends EventEmitter {
       remotePort
     );
 
+    if (socksSocket) debug('using socks proxy for connection to localtunnel server');
+
     // connection to localtunnel server
-    const remote = net.connect({
-      host: remoteHostOrIp,
-      port: remotePort,
-    });
+    const remote = socksSocket
+        ? socksSocket.connect(remotePort, remoteHostOrIp)
+        : net.connect({ host: remoteHostOrIp, port: remotePort })
 
     remote.setKeepAlive(true);
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "axios": "0.21.1",
     "debug": "4.3.1",
     "openurl": "1.1.1",
+    "socks5-client": "^1.2.8",
+    "socks5-http-client": "^1.0.4",
+    "socks5-https-client": "^1.2.1",
     "yargs": "16.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,15 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ip-address@~6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-6.1.0.tgz#3c3335bc90f22b3545a6eca5bffefabeb2ea6fd2"
+  integrity sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==
+  dependencies:
+    jsbn "1.1.0"
+    lodash "^4.17.15"
+    sprintf-js "1.1.2"
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -373,6 +382,11 @@ js-yaml@3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha1-sBMHyym2GKHtJux56RH4A8TaAEA=
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -387,6 +401,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.0.0:
   version "4.0.0"
@@ -553,6 +572,32 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+socks5-client@^1.2.8, socks5-client@~1.2.3, socks5-client@~1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/socks5-client/-/socks5-client-1.2.8.tgz#6470e4d781de254ee9f3b5ec9760a44c5df898da"
+  integrity sha512-js8WqQ/JjZS3IQwUxRwSThvXzcRIHE8sde8nE5q7nqxiFGb8EoHmNJ9SF2lXqn3ux6pUV3+InH7ng7mANK6XfA==
+  dependencies:
+    ip-address "~6.1.0"
+
+socks5-http-client@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/socks5-http-client/-/socks5-http-client-1.0.4.tgz#cfaaa993f91df58542806b458372c6fb3c1a32bd"
+  integrity sha512-K16meYkltPtps6yDOqK9Mwlfz+pdD2kQQQ/TCO/gu2AImUmfO6nF2uXX1YWrPs4NCfClQNih19wqLXmuUcZCrA==
+  dependencies:
+    socks5-client "~1.2.6"
+
+socks5-https-client@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/socks5-https-client/-/socks5-https-client-1.2.1.tgz#c8d4a000e39cdc1651d90245af04a735d75d8b09"
+  integrity sha512-FbZ/X/2Xq3DAMhuRA4bnN0jy1QxaPTVPLFvyv6CEj0QDKSTdWp9yRxo1JhqXmWKhPQeJyUMajHJB2UjT43pFcw==
+  dependencies:
+    socks5-client "~1.2.3"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This PR adds ability to connect to localtunnel server via socks proxy (using Tor for example) thus adding ability to hide real IP address of the client from the server. This is especially useful for people running their own localtunnel server instances because it allows their users to protect against revealing their real IP (and deanonymize them) by a malicious actor. Therefore it makes this service more trustless.

I've tested this locally using default localtunnel server.