### PR TITLE
Localtunnel closed after server restart on windows 10, this PR is supposed to fix it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+package-lock.json

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -1,10 +1,10 @@
-const { EventEmitter } = require('events');
-const debug = require('debug')('localtunnel:client');
-const fs = require('fs');
-const net = require('net');
-const tls = require('tls');
+const { EventEmitter } = require("events");
+const debug = require("debug")("localtunnel:client");
+const fs = require("fs");
+const net = require("net");
+const tls = require("tls");
 
-const HeaderHostTransformer = require('./HeaderHostTransformer');
+const HeaderHostTransformer = require("./HeaderHostTransformer");
 
 // manages groups of tunnels
 module.exports = class TunnelCluster extends EventEmitter {
@@ -19,13 +19,13 @@ module.exports = class TunnelCluster extends EventEmitter {
     // Prefer IP if returned by the server
     const remoteHostOrIp = opt.remote_ip || opt.remote_host;
     const remotePort = opt.remote_port;
-    const localHost = opt.local_host || 'localhost';
+    const localHost = opt.local_host || "localhost";
     const localPort = opt.local_port;
-    const localProtocol = opt.local_https ? 'https' : 'http';
+    const localProtocol = opt.local_https ? "https" : "http";
     const allowInvalidCert = opt.allow_invalid_cert;
 
     debug(
-      'establishing tunnel %s://%s:%s <> %s:%s',
+      "establishing tunnel %s://%s:%s <> %s:%s",
       localProtocol,
       localHost,
       localPort,
@@ -41,14 +41,14 @@ module.exports = class TunnelCluster extends EventEmitter {
 
     remote.setKeepAlive(true);
 
-    remote.on('error', err => {
-      debug('got remote connection error', err.message);
+    remote.on("error", (err) => {
+      debug("got remote connection error", err.message);
 
       // emit connection refused errors immediately, because they
       // indicate that the tunnel can't be established.
-      if (err.code === 'ECONNREFUSED') {
+      if (err.code === "ECONNREFUSED") {
         this.emit(
-          'error',
+          "error",
           new Error(
             `connection refused: ${remoteHostOrIp}:${remotePort} (check your firewall settings)`
           )
@@ -60,16 +60,21 @@ module.exports = class TunnelCluster extends EventEmitter {
 
     const connLocal = () => {
       if (remote.destroyed) {
-        debug('remote destroyed');
-        this.emit('dead');
+        debug("remote destroyed");
+        this.emit("dead");
         return;
       }
 
-      debug('connecting locally to %s://%s:%d', localProtocol, localHost, localPort);
+      debug(
+        "connecting locally to %s://%s:%d",
+        localProtocol,
+        localHost,
+        localPort
+      );
       remote.pause();
 
       if (allowInvalidCert) {
-        debug('allowing invalid certificates');
+        debug("allowing invalid certificates");
       }
 
       const getLocalCertOpts = () =>
@@ -83,27 +88,31 @@ module.exports = class TunnelCluster extends EventEmitter {
 
       // connection to local http server
       const local = opt.local_https
-        ? tls.connect({ host: localHost, port: localPort, ...getLocalCertOpts() })
+        ? tls.connect({
+            host: localHost,
+            port: localPort,
+            ...getLocalCertOpts(),
+          })
         : net.connect({ host: localHost, port: localPort });
 
       const remoteClose = () => {
-        debug('remote close');
-        this.emit('dead');
+        debug("remote close");
+        this.emit("dead");
         local.end();
       };
 
-      remote.once('close', remoteClose);
+      remote.once("close", remoteClose);
 
       // TODO some languages have single threaded servers which makes opening up
       // multiple local connections impossible. We need a smarter way to scale
       // and adjust for such instances to avoid beating on the door of the server
-      local.once('error', err => {
-        debug('local error %s', err.message);
+      local.once("error", (err) => {
+        debug("local error %s", err.message);
         local.end();
 
-        remote.removeListener('close', remoteClose);
+        remote.removeListener("close", remoteClose);
 
-        if (err.code !== 'ECONNREFUSED') {
+        if (err.code !== "ECONNREFUSED" && err.code !== "ECONNRESET") {
           return remote.end();
         }
 
@@ -111,8 +120,8 @@ module.exports = class TunnelCluster extends EventEmitter {
         setTimeout(connLocal, 1000);
       });
 
-      local.once('connect', () => {
-        debug('connected locally');
+      local.once("connect", () => {
+        debug("connected locally");
         remote.resume();
 
         let stream = remote;
@@ -120,23 +129,25 @@ module.exports = class TunnelCluster extends EventEmitter {
         // if user requested specific local host
         // then we use host header transform to replace the host header
         if (opt.local_host) {
-          debug('transform Host header to %s', opt.local_host);
-          stream = remote.pipe(new HeaderHostTransformer({ host: opt.local_host }));
+          debug("transform Host header to %s", opt.local_host);
+          stream = remote.pipe(
+            new HeaderHostTransformer({ host: opt.local_host })
+          );
         }
 
         stream.pipe(local).pipe(remote);
 
         // when local closes, also get a new remote
-        local.once('close', hadError => {
-          debug('local connection closed [%s]', hadError);
+        local.once("close", (hadError) => {
+          debug("local connection closed [%s]", hadError);
         });
       });
     };
 
-    remote.on('data', data => {
+    remote.on("data", (data) => {
       const match = data.toString().match(/^(\w+) (\S+)/);
       if (match) {
-        this.emit('request', {
+        this.emit("request", {
           method: match[1],
           path: match[2],
         });
@@ -144,8 +155,8 @@ module.exports = class TunnelCluster extends EventEmitter {
     });
 
     // tunnel is considered open when remote connects
-    remote.once('connect', () => {
-      this.emit('open', remote);
+    remote.once("connect", () => {
+      this.emit("open", remote);
       connLocal();
     });
   }

--- a/localtunnel.spec.js
+++ b/localtunnel.spec.js
@@ -1,18 +1,18 @@
 /* eslint-disable no-console */
 
-const crypto = require('crypto');
-const http = require('http');
-const https = require('https');
-const url = require('url');
-const assert = require('assert');
+const crypto = require("crypto");
+const http = require("http");
+const https = require("https");
+const url = require("url");
+const assert = require("assert");
 
-const localtunnel = require('./localtunnel');
+const localtunnel = require("./localtunnel");
 
 let fakePort;
 
-before(done => {
+before((done) => {
   const server = http.createServer();
-  server.on('request', (req, res) => {
+  server.on("request", (req, res) => {
     res.write(req.headers.host);
     res.end();
   });
@@ -23,70 +23,69 @@ before(done => {
   });
 });
 
-it('query localtunnel server w/ ident', async done => {
+it("query localtunnel server w/ ident", async () => {
   const tunnel = await localtunnel({ port: fakePort });
-  assert.ok(new RegExp('^https://.*localtunnel.me$').test(tunnel.url));
+  assert.ok(new RegExp("^https://.*loca.lt$").test(tunnel.url));
 
   const parsed = url.parse(tunnel.url);
   const opt = {
     host: parsed.host,
     port: 443,
     headers: { host: parsed.hostname },
-    path: '/',
+    path: "/",
   };
 
-  const req = https.request(opt, res => {
-    res.setEncoding('utf8');
-    let body = '';
+  const req = https.request(opt, (res) => {
+    res.setEncoding("utf8");
+    let body = "";
 
-    res.on('data', chunk => {
+    res.on("data", (chunk) => {
       body += chunk;
     });
 
-    res.on('end', () => {
-      assert(/.*[.]localtunnel[.]me/.test(body), body);
+    res.on("end", () => {
+      assert(/.*[.]loca[.]lt/.test(body), body);
       tunnel.close();
-      done();
     });
   });
 
   req.end();
 });
 
-it('request specific domain', async () => {
-  const subdomain = Math.random()
-    .toString(36)
-    .substr(2);
+it("request specific domain", async () => {
+  const subdomain = Math.random().toString(36).substr(2);
   const tunnel = await localtunnel({ port: fakePort, subdomain });
-  assert.ok(new RegExp(`^https://${subdomain}.localtunnel.me$`).test(tunnel.url));
+  assert.ok(new RegExp(`^https://${subdomain}.loca.lt$`).test(tunnel.url));
   tunnel.close();
 });
 
-describe('--local-host localhost', () => {
-  it('override Host header with local-host', async done => {
-    const tunnel = await localtunnel({ port: fakePort, local_host: 'localhost' });
-    assert.ok(new RegExp('^https://.*localtunnel.me$').test(tunnel.url));
+describe("--local-host localhost", () => {
+  it("override Host header with local-host", async () => {
+    const tunnel = await localtunnel({
+      port: fakePort,
+      local_host: "localhost",
+    });
+    assert.ok(new RegExp("^https://.*loca.lt$").test(tunnel.url));
 
     const parsed = url.parse(tunnel.url);
     const opt = {
       host: parsed.host,
       port: 443,
       headers: { host: parsed.hostname },
-      path: '/',
+      path: "/",
     };
 
-    const req = https.request(opt, res => {
-      res.setEncoding('utf8');
-      let body = '';
+    const req = https.request(opt, (res) => {
+      res.setEncoding("utf8");
+      let body = "";
 
-      res.on('data', chunk => {
+      res.on("data", (chunk) => {
         body += chunk;
       });
 
-      res.on('end', () => {
-        assert.strictEqual(body, 'localhost');
+      res.on("end", () => {
+        assert.strictEqual(body, "localhost");
         tunnel.close();
-        done();
       });
     });
 
@@ -94,10 +93,13 @@ describe('--local-host localhost', () => {
   });
 });
 
-describe('--local-host 127.0.0.1', () => {
-  it('override Host header with local-host', async done => {
-    const tunnel = await localtunnel({ port: fakePort, local_host: '127.0.0.1' });
-    assert.ok(new RegExp('^https://.*localtunnel.me$').test(tunnel.url));
+describe("--local-host 127.0.0.1", () => {
+  it("override Host header with local-host", async () => {
+    const tunnel = await localtunnel({
+      port: fakePort,
+      local_host: "127.0.0.1",
+    });
+    assert.ok(new RegExp("^https://.*loca.lt$").test(tunnel.url));
 
     const parsed = url.parse(tunnel.url);
     const opt = {
@@ -106,30 +108,32 @@ describe('--local-host 127.0.0.1', () => {
       headers: {
         host: parsed.hostname,
       },
-      path: '/',
+      path: "/",
     };
 
-    const req = https.request(opt, res => {
-      res.setEncoding('utf8');
-      let body = '';
+    const req = https.request(opt, (res) => {
+      res.setEncoding("utf8");
+      let body = "";
 
-      res.on('data', chunk => {
+      res.on("data", (chunk) => {
         body += chunk;
       });
 
-      res.on('end', () => {
-        assert.strictEqual(body, '127.0.0.1');
+      res.on("end", () => {
+        assert.strictEqual(body, "127.0.0.1");
         tunnel.close();
-        done();
       });
     });
 
     req.end();
   });
 
-  it('send chunked request', async done => {
-    const tunnel = await localtunnel({ port: fakePort, local_host: '127.0.0.1' });
-    assert.ok(new RegExp('^https://.*localtunnel.me$').test(tunnel.url));
+  it("send chunked request", async () => {
+    const tunnel = await localtunnel({
+      port: fakePort,
+      local_host: "127.0.0.1",
+    });
+    assert.ok(new RegExp("^https://.*loca.lt$").test(tunnel.url));
 
     const parsed = url.parse(tunnel.url);
     const opt = {
@@ -137,26 +141,25 @@ describe('--local-host 127.0.0.1', () => {
       port: 443,
       headers: {
         host: parsed.hostname,
-        'Transfer-Encoding': 'chunked',
+        "Transfer-Encoding": "chunked",
       },
-      path: '/',
+      path: "/",
     };
 
-    const req = https.request(opt, res => {
-      res.setEncoding('utf8');
-      let body = '';
+    const req = https.request(opt, (res) => {
+      res.setEncoding("utf8");
+      let body = "";
 
-      res.on('data', chunk => {
+      res.on("data", (chunk) => {
         body += chunk;
       });
 
-      res.on('end', () => {
-        assert.strictEqual(body, '127.0.0.1');
+      res.on("end", () => {
+        assert.strictEqual(body, "127.0.0.1");
         tunnel.close();
-        done();
       });
     });
 
-    req.end(crypto.randomBytes(1024 * 8).toString('base64'));
+    req.end(crypto.randomBytes(1024 * 8).toString("base64"));
   });
 });


### PR DESCRIPTION
 Localtunnel closed after any tcp error except for ECONREFUSED which was acceptable for Mac OS powered machines since this is the only error we got after restarting our server (e.g. after code change to test) on localhost, but on windows 10 in such a case, we get ECONNRESET error as well wich makes our tunnel close due to the causes described before.