### PR TITLE
fix: send SNI when using TLS

### DIFF
--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -83,7 +83,12 @@ module.exports = class TunnelCluster extends EventEmitter {
 
       // connection to local http server
       const local = opt.local_https
-        ? tls.connect({ host: localHost, port: localPort, ...getLocalCertOpts() })
+        ? tls.connect({
+          host: localHost,
+          port: localPort,
+          servername: localHost,
+          ...getLocalCertOpts(),
+        })
         : net.connect({ host: localHost, port: localPort });
 
       const remoteClose = () => {


### PR DESCRIPTION
SNI is used by some servers to pick the TLS certificate to use. When
missing, the TLS handshake can fail and localtunnel would terminate
abruptly.

This commit adds the `servername` option to the TLS connection which
instructs Node to add the SNI.