### PR TITLE
Call callback only when connection to remote established

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -78,7 +78,7 @@ module.exports = class Tunnel extends EventEmitter {
     })();
   }
 
-  _establish(info) {
+  _establish(info, cb) {
     // increase max event listeners so that localtunnel consumers don't get
     // warning messages as soon as they setup even one listener. See #71
     this.setMaxListeners(info.max_conn + (EventEmitter.defaultMaxListeners || 10));
@@ -88,6 +88,7 @@ module.exports = class Tunnel extends EventEmitter {
     // only emit the url the first time
     this.tunnelCluster.once('open', () => {
       this.emit('url', info.url);
+      cb();
     });
 
     // re-emit socket error
@@ -151,8 +152,7 @@ module.exports = class Tunnel extends EventEmitter {
         this.cachedUrl = info.cached_url;
       }
 
-      this._establish(info);
-      cb();
+      this._establish(info, cb);
     });
   }
 


### PR DESCRIPTION
Hello 👋 ,
It seems that `localtunnel()` returned promise is resolved prematurely here:
https://github.com/localtunnel/localtunnel/blob/c8e85f49624d606730779fc4295a38fd0e650af5/lib/Tunnel.js#L154-L155

Before the connection to remote is established here:
https://github.com/localtunnel/localtunnel/blob/c8e85f49624d606730779fc4295a38fd0e650af5/lib/TunnelCluster.js#L147-L150

We've noticed that in our E2E tests while relying on the tunnel being ready before connecting.
(random trivia: It worked ok till 1st of March, and broke on the 1st ¯\_(ツ)_/¯

This PR is just a suggestion to a possible solution 🙃 