### PR TITLE
Add support for custom config file 

### DIFF
--- a/bin/lt.js
+++ b/bin/lt.js
@@ -16,8 +16,7 @@ const { argv } = yargs
   })
   .option('h', {
     alias: 'host',
-    describe: 'Upstream server providing forwarding',
-    default: 'https://localtunnel.me',
+    describe: 'Upstream server providing forwarding'
   })
   .option('s', {
     alias: 'subdomain',
@@ -49,6 +48,9 @@ const { argv } = yargs
   .option('print-requests', {
     describe: 'Print basic request info',
   })
+  .option('headers',{
+    describe: 'key=value headers added to the requests sent to localtunnel server support multiple by comma separated'
+  })
   .require('port')
   .boolean('local-https')
   .boolean('allow-invalid-cert')
@@ -73,6 +75,7 @@ if (typeof argv.port !== 'number') {
     local_key: argv.localKey,
     local_ca: argv.localCa,
     allow_invalid_cert: argv.allowInvalidCert,
+    headers:argv.headers
   }).catch(err => {
     throw err;
   });

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -13,7 +13,6 @@ const home=process.env.HOME;
 const configFileLocation=home+"/.config/localtunnel/config";
 
 if(!fs.existsSync(configFileLocation)){
-	console.log("dont go here");
 	var getDirName = require('path').dirname;
     fs.mkdir(getDirName(configFileLocation), { recursive: true}, function (err) {
     	if(err) console.log(err);

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -6,6 +6,32 @@ const axios = require('axios');
 const debug = require('debug')('localtunnel:client');
 
 const TunnelCluster = require('./TunnelCluster');
+const fs=require('fs-extra');
+const nconf = require('nconf');
+
+const home=process.env.HOME;
+const configFileLocation=home+"/.config/localtunnel/config";
+
+if(!fs.existsSync(configFileLocation)){
+	console.log("dont go here");
+	var getDirName = require('path').dirname;
+    fs.mkdir(getDirName(configFileLocation), { recursive: true}, function (err) {
+    	if(err) console.log(err);
+	    fs.writeFile(configFileLocation,"{}");
+	});
+}
+
+nconf.file({file:configFileLocation});
+
+if(!nconf.get('server')){
+	nconf.set('server:host','https://localtunnel.me');
+	nconf.save();
+}
+if(!nconf.get('headers')){
+	nconf.set('headers','User-Agent=Axios');
+	nconf.save();
+}
+nconf.save();
 
 module.exports = class Tunnel extends EventEmitter {
   constructor(opts = {}) {
@@ -13,14 +39,17 @@ module.exports = class Tunnel extends EventEmitter {
     this.opts = opts;
     this.closed = false;
     if (!this.opts.host) {
-      this.opts.host = 'https://localtunnel.me';
+      this.opts.host = nconf.get('server:host');
+    }
+    if(!this.opts.headers){
+    	this.opts.headers=nconf.get('headers');
     }
   }
 
   _getInfo(body) {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count } = body;
-    const { host, port: local_port, local_host } = this.opts;
+    const { host, port: local_port, local_host, headers } = this.opts;
     const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
     return {
       name: id,
@@ -37,6 +66,7 @@ module.exports = class Tunnel extends EventEmitter {
       local_key,
       local_ca,
       allow_invalid_cert,
+      headers
     };
     /* eslint-enable camelcase */
   }
@@ -47,8 +77,16 @@ module.exports = class Tunnel extends EventEmitter {
     const opt = this.opts;
     const getInfo = this._getInfo.bind(this);
 
+    let headers={}
+    let _headers=opt.headers;
+    _headers.split(',').forEach((h)=>{
+    	h=h.split('=');
+    	headers[h[0]]=h[1]
+    });
+
     const params = {
       responseType: 'json',
+      headers: headers
     };
 
     const baseUri = `${opt.host}/`;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
   },
   "dependencies": {
     "axios": "0.21.4",
+    "config": "^3.3.7",
     "debug": "4.3.2",
+    "fs-extra": "^10.1.0",
+    "nconf": "^0.12.0",
     "openurl": "1.1.1",
     "yargs": "17.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "axios": "0.21.4",
-    "config": "^3.3.7",
     "debug": "4.3.2",
     "fs-extra": "^10.1.0",
     "nconf": "^0.12.0",


### PR DESCRIPTION
This pull request add the support of custom config file. 
Could be usefull when using your own server if you don't want to always type it's address. 

More it add a support for custom header, a pull request is comming on the server side to handle this header ( as an authentification feature ) 