### PR TITLE
feat: lt login/logout for Basic auth (just like npm login/logout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ You may also specify arguments via env variables. E.x.
 PORT=3000 lt
 ```
 
+## Authentication (Basic auth)
+
+Provide basic auth token if your web server requires authorization.
+
+### login
+
+Save the credentials with <username> and <password> for specified host to the `~/.ltrc` file. If no host is specified, the default host will be used (`https://localtunnel.me`).
+
+```
+lt login https://lt.example.com
+```
+
+### logout
+
+Remove the credentials for specified host from the `~/.ltrc` file.
+
+```
+lt logout https://lt.example.com
+```
+
 ## API
 
 The localtunnel client is also usable through an API (for test integration, automation, etc)

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -5,100 +5,124 @@ const openurl = require('openurl');
 const yargs = require('yargs');
 
 const localtunnel = require('../localtunnel');
+const config = require('../lib/config');
 const { version } = require('../package');
+
+const defaultHost = 'https://localtunnel.me';
 
 const { argv } = yargs
   .usage('Usage: lt --port [num] <options>')
+  .usage('Login: lt login [host]')
+  .usage('Logout: lt logout [host]')
   .env(true)
-  .option('p', {
-    alias: 'port',
-    describe: 'Internal HTTP server port',
-  })
-  .option('h', {
-    alias: 'host',
-    describe: 'Upstream server providing forwarding',
-    default: 'https://localtunnel.me',
-  })
-  .option('s', {
-    alias: 'subdomain',
-    describe: 'Request this subdomain',
-  })
-  .option('l', {
-    alias: 'local-host',
-    describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host',
-  })
-  .option('local-https', {
-    describe: 'Tunnel traffic to a local HTTPS server',
-  })
-  .option('local-cert', {
-    describe: 'Path to certificate PEM file for local HTTPS server',
-  })
-  .option('local-key', {
-    describe: 'Path to certificate key file for local HTTPS server',
-  })
-  .option('local-ca', {
-    describe: 'Path to certificate authority file for self-signed certificates',
-  })
-  .option('allow-invalid-cert', {
-    describe: 'Disable certificate checks for your local HTTPS server (ignore cert/key/ca options)',
-  })
-  .options('o', {
-    alias: 'open',
-    describe: 'Opens the tunnel URL in your browser',
-  })
-  .option('print-requests', {
-    describe: 'Print basic request info',
-  })
-  .require('port')
-  .boolean('local-https')
-  .boolean('allow-invalid-cert')
-  .boolean('print-requests')
-  .help('help', 'Show this help and exit')
-  .version(version);
+  .command('$0', 'Start localtunnel session', () => {
+    return yargs
+      .option('p', {
+        alias: 'port',
+        describe: 'Internal HTTP server port',
+      })
+      .option('h', {
+        alias: 'host',
+        describe: 'Upstream server providing forwarding',
+        default: defaultHost,
+      })
+      .option('s', {
+        alias: 'subdomain',
+        describe: 'Request this subdomain',
+      })
+      .option('l', {
+        alias: 'local-host',
+        describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host',
+      })
+      .option('local-https', {
+        describe: 'Tunnel traffic to a local HTTPS server',
+      })
+      .option('local-cert', {
+        describe: 'Path to certificate PEM file for local HTTPS server',
+      })
+      .option('local-key', {
+        describe: 'Path to certificate key file for local HTTPS server',
+      })
+      .option('local-ca', {
+        describe: 'Path to certificate authority file for self-signed certificates',
+      })
+      .option('allow-invalid-cert', {
+        describe: 'Disable certificate checks for your local HTTPS server (ignore cert/key/ca options)',
+      })
+      .options('o', {
+        alias: 'open',
+        describe: 'Opens the tunnel URL in your browser',
+      })
+      .option('print-requests', {
+        describe: 'Print basic request info',
+      })
+      .boolean('local-https')
+      .boolean('allow-invalid-cert')
+      .boolean('print-requests')
+  }, async (argv) => {
+    if (typeof argv.port !== 'number') {
+      yargs.showHelp();
+      console.error('\nInvalid argument: `port` must be a number');
+      process.exit(1);
+    }
 
-if (typeof argv.port !== 'number') {
-  yargs.showHelp();
-  console.error('\nInvalid argument: `port` must be a number');
-  process.exit(1);
-}
+    const authorization = config.getAuthorization(argv.host);
 
-(async () => {
-  const tunnel = await localtunnel({
-    port: argv.port,
-    host: argv.host,
-    subdomain: argv.subdomain,
-    local_host: argv.localHost,
-    local_https: argv.localHttps,
-    local_cert: argv.localCert,
-    local_key: argv.localKey,
-    local_ca: argv.localCa,
-    allow_invalid_cert: argv.allowInvalidCert,
-  }).catch(err => {
-    throw err;
-  });
-
-  tunnel.on('error', err => {
-    throw err;
-  });
-
-  console.log('your url is: %s', tunnel.url);
-
-  /**
-   * `cachedUrl` is set when using a proxy server that support resource caching.
-   * This URL generally remains available after the tunnel itself has closed.
-   * @see https://github.com/localtunnel/localtunnel/pull/319#discussion_r319846289
-   */
-  if (tunnel.cachedUrl) {
-    console.log('your cachedUrl is: %s', tunnel.cachedUrl);
-  }
-
-  if (argv.open) {
-    openurl.open(tunnel.url);
-  }
-
-  if (argv['print-requests']) {
-    tunnel.on('request', info => {
-      console.log(new Date().toString(), info.method, info.path);
+    const tunnel = await localtunnel({
+      port: argv.port,
+      host: argv.host,
+      subdomain: argv.subdomain,
+      local_host: argv.localHost,
+      local_https: argv.localHttps,
+      local_cert: argv.localCert,
+      local_key: argv.localKey,
+      local_ca: argv.localCa,
+      allow_invalid_cert: argv.allowInvalidCert,
+      authorization,
+    }).catch(err => {
+      throw err;
     });
-  }
-})();
+
+    tunnel.on('error', err => {
+      throw err;
+    });
+
+    console.log('your url is: %s', tunnel.url);
+
+    /**
+     * `cachedUrl` is set when using a proxy server that support resource caching.
+     * This URL generally remains available after the tunnel itself has closed.
+     * @see https://github.com/localtunnel/localtunnel/pull/319#discussion_r319846289
+     */
+    if (tunnel.cachedUrl) {
+      console.log('your cachedUrl is: %s', tunnel.cachedUrl);
+    }
+
+    if (argv.open) {
+      openurl.open(tunnel.url);
+    }
+
+    if (argv['print-requests']) {
+      tunnel.on('request', info => {
+        console.log(new Date().toString(), info.method, info.path);
+      });
+    }
+  })
+  .command('login [host]', 'Add basic auth info for [host]', () => {
+    return yargs.positional('host', {
+      describe: 'Target basic auth host',
+      default: defaultHost,
+    })
+  }, (argv) => {
+    return config.login(argv.host)
+  })
+  .command('logout [host]', 'Remove basic auth info for [host]', () => {
+    return yargs.positional('host', {
+      describe: 'Target basic auth host',
+      default: defaultHost,
+    })
+  }, (argv) => {
+    return config.logout(argv.host)
+  })
+  .help('help', 'Show this help and exit')
+  .version(version)

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -49,6 +49,9 @@ module.exports = class Tunnel extends EventEmitter {
 
     const params = {
       responseType: 'json',
+      headers: {
+        Authorization: opt.authorization || null,
+      },
     };
 
     const baseUri = `${opt.host}/`;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,101 @@
+const ini = require('ini');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const prompt = require('prompt');
+
+const configFileName = '.ltrc'
+
+const homedir = os.homedir();
+
+const configFilePath = path.resolve(homedir, configFileName);
+
+const readConfigFile = () => {
+  try {
+    return ini.parse(fs.readFileSync(configFilePath, 'utf-8'));
+  }
+  catch (err) {
+    return ini.parse('');
+  }
+}
+
+const saveConfigFile = (config) => {
+  fs.writeFileSync(configFilePath, ini.stringify(config));
+}
+
+const loginPromptSchema = {
+  properties: {
+    username: {
+      type: 'string',
+      message: 'username is required',
+      required: true,
+    },
+    password: {
+      type: 'string',
+      hidden: true,
+      message: 'password is required',
+      required: true
+    },
+  },
+};
+
+const getLoginAuthKey = (host) => {
+  const url = new URL(host);
+
+  let href = url.href.replace(url.protocol, '');
+
+  // Append a trailing slash
+  if (href.substr(-1) != '/') {
+    href = href + '/';
+  }
+
+  const key = `${href}:_auth`; // Result: //localtunnel.me/:_auth
+
+  return key;
+}
+
+const login = (host) => {
+  const loginKey = getLoginAuthKey(host);
+
+  prompt.start();
+
+  prompt.get(loginPromptSchema, (err, result) => {
+    const config = readConfigFile();
+
+    const auth = btoa(`${result.username}:${result.password}`);
+
+    config[loginKey] = auth;
+
+    saveConfigFile(config);
+
+    console.log(`Basic auth for %s (%s) has been added!`, host, result.username);
+  });
+}
+
+const logout = (host) => {
+  const loginKey = getLoginAuthKey(host);
+
+  const config = readConfigFile();
+
+  delete config[loginKey];
+
+  saveConfigFile(config);
+
+  console.log('Basic auth for %s has been removed!', host);
+}
+
+const getAuthorization = (host) => {
+  const config = readConfigFile();
+  const loginKey = getLoginAuthKey(host);
+  const auth = config[loginKey];
+
+  if (!auth) return undefined;
+
+  return `Basic ${auth}`;
+}
+
+module.exports = {
+  login,
+  logout,
+  getAuthorization,
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "axios": "0.21.4",
     "debug": "4.3.2",
+    "ini": "^3.0.0",
     "openurl": "1.1.1",
+    "prompt": "^1.3.0",
     "yargs": "17.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -41,6 +46,16 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+async@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
+async@^3.2.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 axios@0.21.4:
   version "0.21.4"
@@ -128,10 +143,20 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==
 
 debug@4.3.1:
   version "4.3.1"
@@ -171,6 +196,11 @@ escape-string-regexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -259,6 +289,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-3.0.0.tgz#2f6de95006923aa75feed8894f5686165adc08f1"
+  integrity sha512-TxYQaeNW/N8ymDvwAxPyRbhMBtnEwuvaTYpOQkFx1nSeusgezHniEc/l35Vo4iCq/mMiTJbpD7oYxN98hFlfmw==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -307,6 +342,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isstream@0.1.x:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 js-yaml@4.1.0:
   version "4.1.0"
@@ -378,6 +418,11 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nanoid@3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
@@ -429,12 +474,30 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+prompt@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.3.0.tgz#b1f6d47cb1b6beed4f0660b470f5d3ec157ad7ce"
+  integrity sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    async "3.2.3"
+    read "1.0.x"
+    revalidator "0.1.x"
+    winston "2.x"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
+  dependencies:
+    mute-stream "~0.0.4"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -448,6 +511,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+  integrity sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -459,6 +527,11 @@ serialize-javascript@6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 "string-width@^1.0.2 || 2":
   version "2.1.1"
@@ -530,6 +603,18 @@ wide-align@1.1.3:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+winston@2.x:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.6.tgz#da616f332928f70aac482f59b43d62228f29e478"
+  integrity sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==
+  dependencies:
+    async "^3.2.3"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
 
 workerpool@6.1.5:
   version "6.1.5"


### PR DESCRIPTION
Save/remove basic auth credentials for specified host.

Config file: `~/.ltrc`

Example:
```ini
//lt.example.com/:_auth=YmFyYWJhbm92OmAoYW5gZW2i
//localtunnel.me/:_auth=YuReYWJacm82OmAoYW5gZW2a
```

So now we can authenticate `create tunnel` requests on the web server side.

Hope that others find this helpful!