### PR TITLE
Fix argument names and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can restart your local server all you want, `lt` is smart enough to detect t
 Below are some common arguments. See `lt --help` for additional arguments
 
 - `--subdomain` request a named subdomain on the localtunnel server (default is random characters)
-- `--localHhost` proxy to a hostname other than localhost
+- `--localHost` proxy to a hostname other than localhost
 
 You may also specify arguments via env variables. E.x.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can restart your local server all you want, `lt` is smart enough to detect t
 Below are some common arguments. See `lt --help` for additional arguments
 
 - `--subdomain` request a named subdomain on the localtunnel server (default is random characters)
-- `--local-host` proxy to a hostname other than localhost
+- `--localHhost` proxy to a hostname other than localhost
 
 You may also specify arguments via env variables. E.x.
 
@@ -78,12 +78,12 @@ const localtunnel = require('localtunnel');
 - `port` (number) [required] The local port number to expose through localtunnel.
 - `subdomain` (string) Request a specific subdomain on the proxy server. **Note** You may not actually receive this name depending on availability.
 - `host` (string) URL for the upstream proxy server. Defaults to `https://localtunnel.me`.
-- `local_host` (string) Proxy to this hostname instead of `localhost`. This will also cause the `Host` header to be re-written to this value in proxied requests.
-- `local_https` (boolean) Enable tunneling to local HTTPS server.
-- `local_cert` (string) Path to certificate PEM file for local HTTPS server.
-- `local_key` (string) Path to certificate key file for local HTTPS server.
-- `local_ca` (string) Path to certificate authority file for self-signed certificates.
-- `allow_invalid_cert` (boolean) Disable certificate checks for your local HTTPS server (ignore cert/key/ca options).
+- `localHost` (string) Proxy to this hostname instead of `localhost`. This will also cause the `Host` header to be re-written to this value in proxied requests.
+- `localHttps` (boolean) Enable tunneling to local HTTPS server.
+- `localCert` (string) Path to certificate PEM file for local HTTPS server.
+- `localKey` (string) Path to certificate key file for local HTTPS server.
+- `localCa` (string) Path to certificate authority file for self-signed certificates.
+- `allowInvalidCert` (boolean) Disable certificate checks for your local HTTPS server (ignore cert/key/ca options).
 
 Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) for details on the certificate options.
 

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -46,13 +46,13 @@ const { argv } = yargs
     alias: 'open',
     describe: 'Opens the tunnel URL in your browser',
   })
-  .option('printRequests', {
+  .option('print-requests', {
     describe: 'Print basic request info',
   })
   .require('port')
   .boolean('localHttps')
   .boolean('allowInvalidCert')
-  .boolean('printRequests')
+  .boolean('print-requests')
   .help('help', 'Show this help and exit')
   .version(version);
 

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -24,35 +24,35 @@ const { argv } = yargs
     describe: 'Request this subdomain',
   })
   .option('l', {
-    alias: 'local-host',
+    alias: 'localHost',
     describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host',
   })
-  .option('local-https', {
+  .option('localHttps', {
     describe: 'Tunnel traffic to a local HTTPS server',
   })
-  .option('local-cert', {
+  .option('localCert', {
     describe: 'Path to certificate PEM file for local HTTPS server',
   })
-  .option('local-key', {
+  .option('localKey', {
     describe: 'Path to certificate key file for local HTTPS server',
   })
-  .option('local-ca', {
+  .option('localCa', {
     describe: 'Path to certificate authority file for self-signed certificates',
   })
-  .option('allow-invalid-cert', {
+  .option('allowInvalidCert', {
     describe: 'Disable certificate checks for your local HTTPS server (ignore cert/key/ca options)',
   })
   .options('o', {
     alias: 'open',
     describe: 'Opens the tunnel URL in your browser',
   })
-  .option('print-requests', {
+  .option('printRequests', {
     describe: 'Print basic request info',
   })
   .require('port')
-  .boolean('local-https')
-  .boolean('allow-invalid-cert')
-  .boolean('print-requests')
+  .boolean('localHttps')
+  .boolean('allowInvalidCert')
+  .boolean('printRequests')
   .help('help', 'Show this help and exit')
   .version(version);
 


### PR DESCRIPTION
When using the `--local-https`, `--local-cert`, `--local-key` and `--allow-invalid-cert` arguments, it exits after printing the address.

- Renamed the arguments in the bin/lt.js file to match it with the references in the code.

- Also edited README accordingly.