### PR TITLE
Add requests validation (allowlisting); fix unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ const localtunnel = require('localtunnel');
 - `local_key` (string) Path to certificate key file for local HTTPS server.
 - `local_ca` (string) Path to certificate authority file for self-signed certificates.
 - `allow_invalid_cert` (boolean) Disable certificate checks for your local HTTPS server (ignore cert/key/ca options).
+- `validate` (function) If passed, this function will be called with `{ method: string; path: string }` argument before the request is proxied. If it returns false, then the request will be rejected with `503 Forbidden` code. This allows to do e.g. paths allow-listing and expose only some of the URLs to the public internet. 
 
 Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) for details on the certificate options.
 
@@ -91,11 +92,11 @@ Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_creat
 
 The `tunnel` instance returned to your callback emits the following events
 
-| event   | args | description                                                                          |
-| ------- | ---- | ------------------------------------------------------------------------------------ |
-| request | info | fires when a request is processed by the tunnel, contains _method_ and _path_ fields |
-| error   | err  | fires when an error happens on the tunnel                                            |
-| close   |      | fires when the tunnel has closed                                                     |
+| event   | args | description                                                                                     |
+| ------- | ---- | ----------------------------------------------------------------------------------------------- |
+| request | info | fires when a request is processed by the tunnel, contains _method_, _path_ and _isValid_ fields |
+| error   | err  | fires when an error happens on the tunnel                                                       |
+| close   |      | fires when the tunnel has closed                                                                |
 
 The `tunnel` instance has the following methods
 

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -42,6 +42,9 @@ const { argv } = yargs
   .option('allow-invalid-cert', {
     describe: 'Disable certificate checks for your local HTTPS server (ignore cert/key/ca options)',
   })
+  .option('paths', {
+    describe: 'Only allow requests to the specified path prefixes (comma-separated)',
+  })
   .options('o', {
     alias: 'open',
     describe: 'Opens the tunnel URL in your browser',
@@ -73,6 +76,9 @@ if (typeof argv.port !== 'number') {
     local_key: argv.localKey,
     local_ca: argv.localCa,
     allow_invalid_cert: argv.allowInvalidCert,
+    validate: ({ path }) => argv.paths 
+      ? argv.paths.split(/\s*,\s*/).some(p => path.startsWith(p))
+      : true,
   }).catch(err => {
     throw err;
   });

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -21,7 +21,7 @@ module.exports = class Tunnel extends EventEmitter {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count } = body;
     const { host, port: local_port, local_host } = this.opts;
-    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
+    const { local_https, local_cert, local_key, local_ca, allow_invalid_cert, validate } = this.opts;
     return {
       name: id,
       url,
@@ -37,6 +37,7 @@ module.exports = class Tunnel extends EventEmitter {
       local_key,
       local_ca,
       allow_invalid_cert,
+      validate,
     };
     /* eslint-enable camelcase */
   }

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -23,6 +23,7 @@ module.exports = class TunnelCluster extends EventEmitter {
     const localPort = opt.local_port;
     const localProtocol = opt.local_https ? 'https' : 'http';
     const allowInvalidCert = opt.allow_invalid_cert;
+    const validate = opt.validate instanceof Function ? opt.validate : null;
 
     debug(
       'establishing tunnel %s://%s:%s <> %s:%s',
@@ -137,10 +138,19 @@ module.exports = class TunnelCluster extends EventEmitter {
     remote.on('data', data => {
       const match = data.toString().match(/^(\w+) (\S+)/);
       if (match) {
-        this.emit('request', {
+        const request = {
           method: match[1],
           path: match[2],
-        });
+        };
+        const isValid = !validate || !!validate(request);
+        this.emit('request', { ...request, isValid });
+        if (!isValid) {
+          remote.end(
+            'HTTP/1.0 403 Forbidden\r\n' +
+              'Content-Type: text/plain\r\n\r\n' +
+              'This path did not pass request validation.\r\n'
+          );
+        }
       }
     });
 


### PR DESCRIPTION
Here we:

- Add an ability to validate the incoming request to e.g. allow-list some urls. It is often times not the best idea to expose ALL localhost URLs, so instead, we can allow-list some of them. (Plus, adding a unit test for it.)
- Add `--paths` command-line option to `lt.js` too.
- Fix unit tests: they did not work before at all because a) they did not support loca.lt domain, and b) mocha did not work with `async done` callbacks - `Resolution method is overspecified. Specify a callback *or* return a Promise; not both`.

Syntax for requests allow-listing:

```js
const tunnel = await localtunnel({
  port: 10142,
  validate: (req) => req.path.startsWith("/webhooks")
});
...
```

In the above example, requests to any paths but `/webhooks*` will result into the following error:

```
403 Forbidden
This path did not pass request validation.
```

## Test plan

```
yarn test

node ./lt.js --port=9004 --subdomain=kjkjkjnjkjn --paths=/aaa

~ > curl https://kjkjkjnjkjn.loca.lt/aaa
Found.

~ > curl https://kjkjkjnjkjn.loca.lt/bad
This path did not pass request validation.
```