### PR TITLE
Fixed redirection when `--local-host` is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ const localtunnel = require('localtunnel');
 - `port` (number) [required] The local port number to expose through localtunnel.
 - `subdomain` (string) Request a specific subdomain on the proxy server. **Note** You may not actually receive this name depending on availability.
 - `host` (string) URL for the upstream proxy server. Defaults to `https://localtunnel.me`.
-- `local_host` (string) Proxy to this hostname instead of `localhost`. This will also cause the `Host` header to be re-written to this value in proxied requests.
+- `local_host` (string) Proxy to this hostname instead of `localhost`.
+- `local_hostname` (string) Re-writes `Host` header to this value in proxied requests.
 - `local_https` (boolean) Enable tunneling to local HTTPS server.
 - `local_cert` (string) Path to certificate PEM file for local HTTPS server.
 - `local_key` (string) Path to certificate key file for local HTTPS server.

--- a/bin/lt.js
+++ b/bin/lt.js
@@ -25,7 +25,10 @@ const { argv } = yargs
   })
   .option('l', {
     alias: 'local-host',
-    describe: 'Tunnel traffic to this host instead of localhost, override Host header to this host',
+    describe: 'Tunnel traffic to this host instead of localhost',
+  })
+  .option('local-hostname', {
+    describe: 'Rewrites the HTTP Host header going to the local server',
   })
   .option('local-https', {
     describe: 'Tunnel traffic to a local HTTPS server',
@@ -68,6 +71,7 @@ if (typeof argv.port !== 'number') {
     host: argv.host,
     subdomain: argv.subdomain,
     local_host: argv.localHost,
+    local_hostname: argv.localHostname,
     local_https: argv.localHttps,
     local_cert: argv.localCert,
     local_key: argv.localKey,

--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -20,7 +20,7 @@ module.exports = class Tunnel extends EventEmitter {
   _getInfo(body) {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count } = body;
-    const { host, port: local_port, local_host } = this.opts;
+    const { host, port: local_port, local_host, local_hostname } = this.opts;
     const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
     return {
       name: id,
@@ -32,6 +32,7 @@ module.exports = class Tunnel extends EventEmitter {
       remote_port: port,
       local_port,
       local_host,
+      local_hostname,
       local_https,
       local_cert,
       local_key,

--- a/lib/TunnelCluster.js
+++ b/lib/TunnelCluster.js
@@ -20,6 +20,7 @@ module.exports = class TunnelCluster extends EventEmitter {
     const remoteHostOrIp = opt.remote_ip || opt.remote_host;
     const remotePort = opt.remote_port;
     const localHost = opt.local_host || 'localhost';
+    const localHostname = opt.local_hostname;
     const localPort = opt.local_port;
     const localProtocol = opt.local_https ? 'https' : 'http';
     const allowInvalidCert = opt.allow_invalid_cert;
@@ -120,9 +121,9 @@ module.exports = class TunnelCluster extends EventEmitter {
 
         // if user requested specific local host
         // then we use host header transform to replace the host header
-        if (opt.local_host) {
-          debug('transform Host header to %s', opt.local_host);
-          stream = remote.pipe(new HeaderHostTransformer({ host: opt.local_host }));
+        if (localHostname) {
+          debug('transform Host header to %s', localHostname);
+          stream = remote.pipe(new HeaderHostTransformer({ host: localHostname }));
         }
 
         stream.pipe(local).pipe(remote);


### PR DESCRIPTION
Split the HTTP Host header rewrite of the `--local-host` argument to a new `--local-hostname` argument. This new argument is the only thing in control of rewriting this hostname. Which allows for correct redirects in the case a server redirects using the location header. This would fix localtunnel/localtunnel#642.

The descriptions of these arguments are the following within the `--help` menu.
```
  -l, --local-host                Tunnel traffic to this host instead of localhost
      --local-hostname      Rewrites the HTTP Host header going to the local
```

Only further thing to note is that this currently does not fix server side redirecting to `http` when a user connects with `https` to the tunnel. This would require another HeaderTransformer within TunnelCluster.js to keep the protocol the same within the `Location` header send to the client. Currently can't find a way to detect this initial connection protocol as of writing this.




