### PR TITLE
add 5s timeout to the tunnel info request

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -49,6 +49,7 @@ module.exports = class Tunnel extends EventEmitter {
 
     const params = {
       responseType: 'json',
+      timeout: 5000,
     };
 
     const baseUri = `${opt.host}/`;
@@ -58,6 +59,7 @@ module.exports = class Tunnel extends EventEmitter {
     const uri = baseUri + (assignedDomain || '?new');
 
     (function getUrl() {
+      debug('getting tunnel information', {uri, params});
       axios
         .get(uri, params)
         .then(res => {


### PR DESCRIPTION
I saw this request sometimes hanging forever. This timeout solved it for me, if it fails then the app restarts and new tunnel is established.