### PR TITLE
Support remote_headers option

### DIFF
--- a/lib/Tunnel.js
+++ b/lib/Tunnel.js
@@ -20,7 +20,7 @@ module.exports = class Tunnel extends EventEmitter {
   _getInfo(body) {
     /* eslint-disable camelcase */
     const { id, ip, port, url, cached_url, max_conn_count } = body;
-    const { host, port: local_port, local_host } = this.opts;
+    const { host, port: local_port, local_host, remote_headers } = this.opts;
     const { local_https, local_cert, local_key, local_ca, allow_invalid_cert } = this.opts;
     return {
       name: id,
@@ -37,6 +37,7 @@ module.exports = class Tunnel extends EventEmitter {
       local_key,
       local_ca,
       allow_invalid_cert,
+      remote_headers
     };
     /* eslint-enable camelcase */
   }
@@ -50,6 +51,10 @@ module.exports = class Tunnel extends EventEmitter {
     const params = {
       responseType: 'json',
     };
+
+    if (typeof opt.remote_headers === 'object') {
+      params.headers = opt.remote_headers;
+    }
 
     const baseUri = `${opt.host}/`;
     // no subdomain at first, maybe use requested domain


### PR DESCRIPTION
This change will allow the axios params to support remote_headers option for passing arbitrary request headers when creating tunnel on server.